### PR TITLE
Fix DB sync script not creating public schema

### DIFF
--- a/db_reset.sh
+++ b/db_reset.sh
@@ -12,7 +12,7 @@ echo "Getting backups from ${BACKUPS_BUCKET}"
 # 4. Insert drop schema to the beginning
 # 5. Run the commands in a single transaction and exit on error
 # So if anything of the above fails, the database should be left untouched
-aws s3 cp s3://${BACKUPS_BUCKET}/ietfa.torchbox.gz - | gzip -d -c | pg_restore -xO -f - | sed "1s/^/DROP SCHEMA public CASCADE;/" | psql "$DATABASE_URL" -v ON_ERROR_STOP=1 --single-transaction -f -
+aws s3 cp s3://${BACKUPS_BUCKET}/ietfa.torchbox.gz - | gzip -d -c | pg_restore -xO -f - | sed "1s/^/DROP SCHEMA public CASCADE; CREATE SCHEMA public;/" | psql "$DATABASE_URL" -v ON_ERROR_STOP=1 --single-transaction -f -
 
 python manage.py migrate --noinput
 


### PR DESCRIPTION
This PR fixes an issue where the public schema won't be recreated during DB sync script runs.