### PR TITLE
Fix/image block caption spacing

### DIFF
--- a/ietf/static_src/css/streamfield.scss
+++ b/ietf/static_src/css/streamfield.scss
@@ -19,6 +19,9 @@
 }
 
 .caption {
+    // Undo space under images. Caption should sit close.
+    margin-top: -1.3em;
+
     margin-bottom: 1.5em;
     font-size: 14px;
     color: #666666;


### PR DESCRIPTION
This PR applies a CSS fix for image block caption spacing

Fixes #175