### PR TITLE
Springload changes for #240, #241 & #243

### DIFF
--- a/ietf/bibliography/templates/bibliography/bibliography.html
+++ b/ietf/bibliography/templates/bibliography/bibliography.html
@@ -1,6 +1,8 @@
 {% if items %}
+
     <div id="bibliography" class="u-max-text-width">
-        <h2 class="h4">Bibliography</h2>
+        <div class="block-paragraph">
+        <h2 class="h3">Bibliography</h2>
         <ul class="list-unstyled">
             {% for item in items %}
                 <li>
@@ -19,5 +21,8 @@
                 </li>
             {% endfor %}
         </ul>
+        </div>
+        
+        
     </div>
 {% endif %}

--- a/ietf/blog/templates/blog/blog_page.html
+++ b/ietf/blog/templates/blog/blog_page.html
@@ -10,7 +10,7 @@
 <div class="bg-white">
     <div id="content">
         <div class="container">
-            <div class="row align-items-stretch g-0">
+            <div class="row align-items-start g-0">
                 <aside class="col-12 col-lg-4 d-flex flex-column bg-light d-lg-none" aria-label="Blog listing">
                     <div class="d-none d-lg-block">
                         {% include "includes/blog_sidebar.html" with siblings=siblings current=self %}
@@ -22,7 +22,7 @@
                         {% include 'includes/breadcrumbs.html' %}
 
                         <button
-                            class="btn btn-outline-primary w-100 mb-4 d-lg-none collapsed"
+                            class="btn btn-outline-primary w-100 mb-3 d-lg-none collapsed"
                             type="button"
                             data-bs-toggle="collapse"
                             data-bs-target="#blog_sidebar"
@@ -32,7 +32,7 @@
                             Blog listing
                             <span class="icon ion-ios-arrow-down"></span>
                         </button>
-                        <div id="blog_sidebar" class="collapse">
+                        <div id="blog_sidebar" class="mb-3 collapse">
                             {% include "includes/blog_sidebar.html" with siblings=siblings current=self %}
                         </div>
 
@@ -48,8 +48,9 @@
                         {{ self.prepared_body|safe }}
 
                         {% bibliography self %}
+                        <hr>
                     </div>
-                    <hr>
+                    
                     <div class="px-3 px-xl-5 mt-5 mb-5">
                         {% include "includes/social_share.html" with page=self settings=settings only %}
                     </div>

--- a/ietf/blog/templates/includes/blog_filters.html
+++ b/ietf/blog/templates/includes/blog_filters.html
@@ -1,6 +1,6 @@
 {% comment %} Mobile view {% endcomment %}
 <button
-    class="btn btn-outline-primary d-md-none w-100 mb-3"
+    class="btn btn-outline-primary d-md-none w-100 mb-4"
     type="button"
     data-bs-toggle="collapse"
     data-bs-target="#filters-mobile"
@@ -10,7 +10,7 @@
     Show filters
     <span class="icon ion-ios-arrow-down"></span>
 </button>
-<form method="GET" action="{{ parent_url }}" id="filters-mobile" class="form-row mx-0 mb-3 d-md-none collapse">
+<form method="GET" action="{{ parent_url }}" id="filters-mobile" class="form-row mx-0 mb-4 d-md-none collapse">
     <h2 class="h6">Filter by topic and date</h2>
     <div class="col-12 form-group p-0 flex-shrink-1">
         <label class="form-label" for="topic-input">Topic</label>
@@ -61,7 +61,7 @@
 </form>
 {% comment %} Desktop view {% endcomment %}
 <h2 class="h6 d-none d-md-block">Filter by topic and date</h2>
-<form method="GET" action="{{ parent_url }}" class="form-row mx-0 mb-3 flex-md-nowrap d-none d-md-flex">
+<form method="GET" action="{{ parent_url }}" class="form-row mx-0 mb-5 flex-md-nowrap d-none d-md-flex">
     <div class="col-auto form-group p-0 flex-shrink-1">
         <label class="form-label" for="topic-desktop-input">Topic</label>
         <select aria-label="Topic" class="form-control bg-light" name="topic" id="topic-desktop-input">

--- a/ietf/blog/templates/includes/blog_sidebar.html
+++ b/ietf/blog/templates/includes/blog_sidebar.html
@@ -6,7 +6,7 @@
 {% endif %}
 <ul class="list-unstyled mb-0">
     {% for sibling in siblings %}
-        <li class="card border-top-0 {% if sibling.slug == current.slug %}bg-white{% else %}bg-light{% endif %}">
+        <li class="card border-bottom-0 {% if sibling.slug == current.slug %}bg-white{% else %}bg-light{% endif %}">
             <div class="card-body">
                 <h2 class="h4"><a class="stretched-link" href="{{ sibling.url }}">{{ sibling.title }}</a></h2>
                 <p class="card-text">{{ sibling.feed_text }}</p>
@@ -15,11 +15,11 @@
             </div>
         </li>
     {% empty %}
-        <li class="card border-top-0 bg-light">
+        <li class="card bg-light">
             <div class="card-body"><p class="card-text">No results</p></div>
         </li>
     {% endfor %}
-    <li class="card border-top-0 bg-light">
+    <li class="card bg-light">
         <div class="card-body">
             <a class="stretched-link" href="{% routablepageurl current.get_parent.specific 'all_entries' %}">
                 Show all

--- a/ietf/standard/templates/standard/standard_index_page.html
+++ b/ietf/standard/templates/standard/standard_index_page.html
@@ -11,11 +11,11 @@
       {% has_tabs self.key_info self.in_depth as show_tabs %}
       {% if show_tabs %}
         <ul class="nav nav-tabs text-uppercase text-center no-js-hide" id="tabs" role="tablist" aria-owns="key-info-tab in-depth-tab">
-          <li class="nav-item flex-grow-1" role="presentation">
+          <li class="nav-item border flex-grow-1" role="presentation">
             <a class="nav-link active" id="key-info-tab" data-bs-toggle="tab" href="#key-info" role="tab"
               aria-controls="key-info" aria-selected="true">Key Info</a>
           </li>
-          <li class="nav-item flex-grow-1" role="presentation">
+          <li class="nav-item border flex-grow-1" role="presentation">
             <a class="nav-link" id="in-depth-tab" data-bs-toggle="tab" href="#in-depth" role="tab" aria-controls="in-depth"
               aria-selected="false">In Depth</a>
           </li>
@@ -59,9 +59,9 @@
 {% endblock head_content %}
 
 {% block content %}
-
+<div class="bg-white">
 <div class="container">
-  <ul class="row list-unstyled mt-5">
+  <ul class="row list-unstyled pt-5 pb-4 mb-0">
     {% for child in self.children %}
         <li class="col-12 col-lg-6 mb-4">
           <h2 class="h3"><a href="{% pageurl child %}">{{ child.title }}<span class="icon ion-ios-arrow-forward ms-3"></span></a></h2>
@@ -86,5 +86,7 @@
 
   </ul>
 </div>
+</div>
+
 
 {% endblock %}

--- a/ietf/standard/templates/standard/standard_page.html
+++ b/ietf/standard/templates/standard/standard_page.html
@@ -6,7 +6,7 @@
 
     <main id="content">
 
-        <div class="bg-white border-bottom pb-3">
+        <div class="bg-white pb-3">
             <div class="container">
                 {% include 'includes/breadcrumbs.html' %}
                 {% include 'includes/optional-introduction.html' with value=self %}
@@ -14,12 +14,13 @@
             </div>
         </div>
 
+        <div class="bg-white">
         <div class="container">
-            <div class="row g-0 align-items-stretch justify-content-between">
+            <div class="row g-0 align-items-start justify-content-between">
                 
                 {# main content row #}
-                <div class="col-12 col-lg-8 col-xl-9 pt-3 pt-lg-5 pe-lg-3">
                 {% has_tabs self.prepared_key_info self.prepared_in_depth as show_tabs %}
+                <div class="col-12 col-lg-8 col-xl-9 pe-lg-3">
                 {% if show_tabs %}
                 {% comment %} 
                     Bootstrap requires this markup (ul > li > a) to style and handle tabs properly,
@@ -29,19 +30,22 @@
                         Adding `aria-owns` listing the tabs should correct this.
                     - the <li> elements have a listitem role by default which doesn't belong in a tablist but an element with role list or group
                         -> we remove the default role by adding `role="presentation"` which actually sets the role for this element to `none`
-                 {% endcomment %}
+                {% endcomment %}
+                    <div class="pt-3 pt-lg-5 border-top">
                     <ul class="nav nav-tabs text-uppercase text-center no-js-hide" id="tabs" role="tablist" aria-owns="key-info-tab in-depth-tab">
-                        <li class="nav-item flex-grow-1" role="presentation">
+                        <li class="nav-item border flex-grow-1" role="presentation">
                             <a class="nav-link active" id="key-info-tab" data-bs-toggle="tab" href="#key-info" role="tab" aria-controls="key-info" aria-selected="true">Key Info</a>
                         </li>
-                        <li class="nav-item flex-grow-1" role="presentation">
+                        <li class="nav-item border flex-grow-1" role="presentation">
                             <a class="nav-link" id="in-depth-tab" data-bs-toggle="tab" href="#in-depth" role="tab" aria-controls="in-depth" aria-selected="false">In Depth</a>
                         </li>
                     </ul>
+                    </div>
+                    
                 {% endif %}
 
                     {# content #}
-                    <div class="mb-3" >
+                    <div class="mb-3 {% if not show_tabs %}pt-3 pt-lg-5 border-top{% endif %}">
                         <div class="{% if show_tabs %}mb-3 tab-content bg-white border border-top-0 no-js-hide{% endif %}">
                             {% if self.prepared_key_info %}
                                 <div id="key-info" class="u-max-text-width{% if show_tabs %} tab-pane fade show active p-3" tabindex="0" role="tabpanel" aria-labelledby="key-info-tab{% endif %}">
@@ -96,6 +100,7 @@
                 {% include "includes/row_siblings_in_section.html" with page=self %}
             </div>
 
+        </div>
         </div>
 
     </main>

--- a/ietf/static_src/css/bs-override.scss
+++ b/ietf/static_src/css/bs-override.scss
@@ -1,0 +1,10 @@
+// Overriding IEFT base themes and bootstrap.
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-weight: 600;
+}

--- a/ietf/static_src/css/main.scss
+++ b/ietf/static_src/css/main.scss
@@ -1,6 +1,7 @@
-@import "@ietf-tools/common-bootstrap-theme/scss/ietf-theme.scss";
-@import "bootstrap/scss/bootstrap";
+@import '@ietf-tools/common-bootstrap-theme/scss/ietf-theme.scss';
+@import 'bootstrap/scss/bootstrap';
 
+@import './bs-override.scss';
 @import './icons.scss';
 @import './pages.scss'; // Styles for page templates
 @import '../../templates/includes/styles/index.scss'; // Styles for global includes template files

--- a/ietf/templates/includes/breadcrumbs.html
+++ b/ietf/templates/includes/breadcrumbs.html
@@ -2,11 +2,11 @@
 
 {% if self.get_ancestors|length > 1 %}
 <nav aria-label="breadcrumbs">
-    <ol class="breadcrumb bg-transparent pt-4 mb-0 {% if dark_bg %}text-white{% endif %}">
-        <li class="breadcrumb-item h5"><a class="{% if dark_bg %}text-white{% else %}text-dark{% endif %}" aria-label="Home" href="/"><span class="icon ion-android-home" ></span></a></li>
+    <ol class="breadcrumb bg-transparent pt-4 mb-4 {% if dark_bg %}text-white{% endif %}">
+        <li class="breadcrumb-item"><a class="{% if dark_bg %}text-white{% else %}text-dark{% endif %}" aria-label="Home" href="/"><span class="icon ion-android-home" ></span></a></li>
         {% for page in self.get_ancestors %}
             {% if not page.slug == "root" and not page.url == '/' %}
-                <li class="breadcrumb-item h5{% if page.url == self.url %} active{% endif %}"><a class="{% if dark_bg %}text-white{% else %}text-dark{% endif %}" href="{% pageurl page %}">{{ page.title }}</a></li>
+                <li class="breadcrumb-item {% if page.url == self.url %} active{% endif %}"><a class="{% if dark_bg %}text-white{% else %}text-dark{% endif %}" href="{% pageurl page %}">{{ page.title }}</a></li>
             {% endif %}
         {% endfor %}
     </ol>

--- a/ietf/templates/includes/row_siblings_in_section.html
+++ b/ietf/templates/includes/row_siblings_in_section.html
@@ -1,5 +1,6 @@
-<nav aria-label="In this section" class="bg-white col-12 col-lg-4 col-xl-3 p-3 p-lg-5 {{ class }}">
-    <h2 class="h5 text-uppercase"><a class="text-dark" href="{{ page.get_parent.url }}">{{ page.get_parent.title }}</a></h2>
+<nav aria-label="In this section" class="bg-body border col-12 col-lg-4 col-xl-3 p-3 p-lg-5 mb-4 {{ class }}">
+    <h2 class="h5 mb-3"><a class="text-dark" href="{{ page.get_parent.url }}">{{ page.get_parent.title }}</a></h2>
+    <div class="block-paragraph">
     <ul class="list-unstyled">
       {% for sibling in page.siblings %}
         {% if sibling.slug == page.slug %}
@@ -20,4 +21,5 @@
         {% endif %}
       {% endfor %}
     </ul>
+    </div>
 </nav>

--- a/ietf/templates/includes/styles/index.scss
+++ b/ietf/templates/includes/styles/index.scss
@@ -1,22 +1,34 @@
 @import 'header.scss';
 
 .block-paragraph {
+    & h2,
+    & h3,
+    & h4 {
+        margin-bottom: 1.3rem;
+    }
+
     & h2 {
         font-size: 2rem;
-        font-weight: 600;
         margin-top: 2rem;
-        margin-bottom: 1.3rem;
+        &:first-child {
+            margin-top: 0;
+        }
     }
 
     & h3 {
         font-size: 1.5rem;
-        font-weight: 600;
-        margin-bottom: 1.3rem;
     }
 
     & h4 {
+        font-size: 1.25rem;
+    }
+
+    & h5 {
         font-size: 1rem;
-        font-weight: 600;
-        margin-bottom: 1.3rem;
+    }
+
+    p,
+    li {
+        font-weight: 300;
     }
 }

--- a/ietf/topics/templates/topics/primary_topic_page.html
+++ b/ietf/topics/templates/topics/primary_topic_page.html
@@ -5,11 +5,11 @@
 {% block main_content %}
 
     <main id="content">
-        <div class="bg-white border-bottom">
+        <div class="bg-white">
             <div class="container">
 
                 {% include 'includes/breadcrumbs.html' %}
-                <div class="row mb-4">
+                <div class="row pb-4">
                     <div class="col-12 col-lg-8 col-xl-9 order-3 order-lg-2">
                         {% include 'includes/optional-introduction.html' with value=self %}
                     </div>
@@ -22,26 +22,29 @@
                 </div>
             </div>
         </div>
+        <div class="bg-white">
         <div class="container">
-            <div class="row g-0 align-items-stretch justify-content-between">
-                <div class="col-12 col-lg-8 col-xl-9 pt-3 pt-lg-5">
+            <div class="row g-0 align-items-start justify-content-between">
+                <div class="col-12 col-lg-8 col-xl-9">
                     {% if self.key_info or self.in_depth %}
                     <div class="no-js-hide u-max-text-width pe-lg-3">
                         {% has_tabs self.key_info self.in_depth as show_tabs %}
                         {% if show_tabs %}
+                        <div class="pt-3 pt-lg-5 border-top">
                         <ul class="nav nav-tabs text-uppercase text-center no-js-hide" id="tabs" role="tablist" aria-owns="key-info-tab in-depth-tab">
-                            <li class="nav-item flex-grow-1" role="presentation">
+                            <li class="nav-item border flex-grow-1" role="presentation">
                                 <a class="nav-link active" id="key-info-tab" data-bs-toggle="tab" href="#key-info" role="tab"
                                     aria-controls="key-info" aria-selected="true">Key Info</a>
                             </li>
-                            <li class="nav-item flex-grow-1" role="presentation">
+                            <li class="nav-item border flex-grow-1" role="presentation">
                                 <a class="nav-link" id="in-depth-tab" data-bs-toggle="tab" href="#in-depth" role="tab" aria-controls="in-depth"
                                     aria-selected="false">In Depth</a>
                             </li>
                         </ul>
+                        </div>
                         {% endif %}
                     
-                        <div class="mb-3">
+                        <div class="mb-3 {% if not show_tabs %}pt-3 pt-lg-5 border-top{% endif %}">
                             <div class="{% if show_tabs %}mb-3 tab-content bg-white border border-top-0 no-js-hide{% endif %}">
                                 {% if self.key_info %}
                                 <div id="key-info" class="{% if show_tabs %} tab-pane fade show active p-3" tabindex="0" role="tabpanel"
@@ -87,6 +90,7 @@
                 {% include "includes/row_siblings_in_section.html" with page=self %}
             </div>
             
+        </div>
         </div>
         <div class="d-lg-none">
             {% include "includes/highlight.html" %}


### PR DESCRIPTION
Changes made:

- Change background colour from grey to white
- Add 24px bottom padding to breadcrumb and remove heading style
- Increase all headings weight to 600
- Reduce body weight to 300
- Remove Uppercase styling on sidebar heading
- Add border and change bg colour to grey in sidebar
- Divider line (between header and body) constrained to margins (rather than spanning whole page width). 


Springload figma link: https://www.figma.com/file/QdmAlSacAoO23ru613kMhZ/IETF-UI-tweaks?node-id=78%3A19&t=lAmRHoslsYHVp0bU-0

From this:
<img width="592" alt="Screen Shot 2022-12-21 at 1 53 43 PM" src="https://user-images.githubusercontent.com/13722738/208795272-53d4e5e6-aab4-4db3-9a68-93f6ccc82942.png">

to this: 
<img width="1561" alt="Screen Shot 2022-12-21 at 2 22 11 PM" src="https://user-images.githubusercontent.com/13722738/208798332-c1ff08ec-7bfd-42f4-b2bd-7f8f0802ee17.png">


