### PR TITLE
fix: images in tables shrink to fit

### DIFF
--- a/ietf/static_src/css/streamfield.scss
+++ b/ietf/static_src/css/streamfield.scss
@@ -75,6 +75,11 @@ $border-colour: #bebebe;
         > tbody {
             width: 100%;
             background-color: $white;
+
+            img {
+                height: auto;
+                max-width: 100%;
+            }
         }
 
         > caption {


### PR DESCRIPTION
Make images in typed tables shrink to fit as per [this comment](https://springload-nz.atlassian.net/browse/IEF-24?focusedCommentId=44563).

