### PR TITLE
feat: Run tests with pytest and measure coverage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,6 +88,7 @@ COPY docker/init-dev.sh /app/docker/
 
 ADD https://raw.githubusercontent.com/mrako/wait-for/d9699cb9fe8a4622f05c4ee32adf2fd93239d005/wait-for /usr/local/bin/
 USER root
+RUN pip3 install pytest-django pytest-cov
 RUN chmod +rx /usr/local/bin/wait-for
 USER www
 
@@ -106,6 +107,7 @@ COPY docker/init-test.sh /app/docker/
 
 ADD https://raw.githubusercontent.com/mrako/wait-for/d9699cb9fe8a4622f05c4ee32adf2fd93239d005/wait-for /usr/local/bin/
 USER root
+RUN pip3 install pytest-django pytest-cov
 RUN chmod +rx /usr/local/bin/wait-for
 USER www
 

--- a/docker/init-dev.sh
+++ b/docker/init-dev.sh
@@ -2,4 +2,4 @@
 
 python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
-/usr/local/bin/gunicorn --config /app/docker/gunicorn.py --reload ietf.wsgi
+exec /usr/local/bin/gunicorn --config /app/docker/gunicorn.py --reload ietf.wsgi

--- a/docker/init-test.sh
+++ b/docker/init-test.sh
@@ -3,5 +3,5 @@
 python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
 python /app/manage.py collectstatic --no-input
-python /app/manage.py test --no-input
+pytest --cov
 python /app/manage.py makemigrations --check --dry-run --no-input

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+addopts = "--reuse-db"
+python_files = "ietf/*/test*.py"


### PR DESCRIPTION
This patch adds [pytest-django](https://pytest-django.readthedocs.io/en/latest/index.html), to run the testsuite with pytest, and [pytest-cov](https://github.com/pytest-dev/pytest-cov), to measure coverage.

Refs. https://github.com/ietf-tools/wagtail_website/issues/131
