### PR TITLE
feat: Upload coverage reports to Codecov

### DIFF
--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -31,4 +31,12 @@ jobs:
         run: docker run --name=memcached -d memcached:latest
 
       - name: Run tests
-        run: docker run -i --rm --name=app-test -u root --link=database --link=memcached -e DATABASE_URL="postgres://postgres:password@database/app" -e APP_SECRET_KEY=xxxx -e ENVIRONMENT=test app-test
+        run: |
+          set -x
+          docker run -i --rm --name=app-test -u root --link=database --link=memcached -e DATABASE_URL="postgres://postgres:password@database/app" -e APP_SECRET_KEY=xxxx -e ENVIRONMENT=test -v $(pwd)/coverage:/coverage app-test
+          cp coverage/.coverage ./
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4-beta
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-run-tests.yml
+++ b/.github/workflows/ci-run-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           set -x
           docker run -i --rm --name=app-test -u root --link=database --link=memcached -e DATABASE_URL="postgres://postgres:password@database/app" -e APP_SECRET_KEY=xxxx -e ENVIRONMENT=test -v $(pwd)/coverage:/coverage app-test
-          cp coverage/.coverage ./
+          cp coverage/.coverage coverage/coverage.xml ./
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4-beta

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 ietf/templates/base.html
 ietf/static/dist
 docker/database/*.gz
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ietf/templates/base.html
 ietf/static/dist
 docker/database/*.gz
 .coverage
+coverage.xml

--- a/docker/init-test.sh
+++ b/docker/init-test.sh
@@ -3,6 +3,6 @@
 python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
 python /app/manage.py collectstatic --no-input
-pytest --cov
-if [ -d /coverage ]; then cp .coverage /coverage/; fi
+pytest --cov --cov-report=xml
+if [ -d /coverage ]; then cp .coverage coverage.xml /coverage/; fi
 python /app/manage.py makemigrations --check --dry-run --no-input

--- a/docker/init-test.sh
+++ b/docker/init-test.sh
@@ -4,4 +4,5 @@ python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
 python /app/manage.py collectstatic --no-input
 pytest --cov
+if [ -d /coverage ]; then cp .coverage /coverage/; fi
 python /app/manage.py makemigrations --check --dry-run --no-input


### PR DESCRIPTION
This PR generates an XML coverage report and uploads it to Codecov. It needs the `CODECOV_TOKEN` actions secret to be set on the repository (IIUC it's already there).

Here's a report uploaded from my fork: https://app.codecov.io/github/mgax/ietf-wagtail_website/commit/66b3878f087ba707ab345e4cfb6ca498cdba27cd/tree

Refs. https://github.com/ietf-tools/wagtail_website/pull/339#issuecomment-1798096246
Fixes https://github.com/ietf-tools/wagtail_website/issues/131