### PR TITLE
fix: Improve developer experience

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/erbium
+16

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ So the only requirement to run it locally is a recent version of Docker with doc
 
 ##### How to run (with a database dump)
 
-1. Obtain a recent database dump with name like `ietfa.torchbox.*.gz` and place in `docker/database/` directory. Otherwise, it will start with a fresh database.
+1. Obtain a recent database dump with name like `ietfa.*.gz` and place in `docker/database/` directory. Otherwise, it will start with a fresh database.
 2. Obtain and unarchive media files into `media/` folder.
 3. Run `docker compose up`. It will build and start the frontend builder (`yarn run start`) and the backend (`python manage.py runserver` analog), along with a Postgresql database. The first run will take a while because the database dump needs to be restored.
 4. After the frontend compilation finishes, the website should become available at http://localhost:8001
 5. Create a super user on **Python application** docker instance to access http://localhost:8001/admin
 
-```sh
-docker exec -ti wagtail_website-application-1 python manage.py createsuperuser
-```
+    ```sh
+    docker exec -ti wagtail_website-application-1 python manage.py createsuperuser
+    ```
 
 6. To destroy everything (i.e. start the database from scratch) run `docker compose down`.
 
@@ -54,9 +54,9 @@ docker exec -ti wagtail_website-application-1 python manage.py createsuperuser
 1. Run `docker compose up`. It will build and start the frontend builder (`yarn run start`) and the backend (`python manage.py runserver` analog), along with a Postgresql database. The first run will take a while because the database dump needs to be restored.
 2. Create an admin user
 
-```sh
-docker exec -ti wagtail_website-application-1 python manage.py createsuperuser
-```
+    ```sh
+    docker exec -ti wagtail_website-application-1 python manage.py createsuperuser
+    ```
 
 3. Log into http://localhost:8001/admin
 4. Create a new "Home Page" (page type must be `Home Page`) and **publish**.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         volumes:
             - ".:/app"
         ports:
-            - "8001:8000"
+            - "${DOCKER_APPLICATION_PORT:-8001}:8000"
         env_file:
             - docker/dev.env
         depends_on:

--- a/docker/database/02_convert_native_dump_to_sql_and_restore.sh
+++ b/docker/database/02_convert_native_dump_to_sql_and_restore.sh
@@ -5,7 +5,7 @@
 cd /docker-entrypoint-initdb.d
 
 set +e
-FILE=$(ls -1 ietfa.torchbox.* | head)
+FILE=$(ls -1 ietfa.*.gz | head)
 
 set -e
 

--- a/docker/init-dev.sh
+++ b/docker/init-dev.sh
@@ -2,4 +2,4 @@
 
 python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
-exec /usr/local/bin/gunicorn --config /app/docker/gunicorn.py --reload ietf.wsgi
+exec ./manage.py runserver 0:8000

--- a/docker/init-dev.sh
+++ b/docker/init-dev.sh
@@ -2,4 +2,4 @@
 
 python /app/manage.py migrate --no-input
 python /app/manage.py createcachetable
-exec ./manage.py runserver 0:8000
+exec /usr/local/bin/gunicorn --config /app/docker/gunicorn.py --reload ietf.wsgi


### PR DESCRIPTION
- Alow for more flexibility in database dump filenames
- Fix indentation in the README Markdown
- ~Use Django's `runserver` instead of gunicorn~
- Allow changing the port exposed by Docker
- Specify the Node version in `.nvmrc` that matches the frontend Dockerfile