### PR TITLE
fix: Remove spaceless template tag

### DIFF
--- a/ietf/templates/iab_base.html
+++ b/ietf/templates/iab_base.html
@@ -1,5 +1,4 @@
 {% load compress static wagtailuserbar wagtailcore_tags wagtailimages_tags ietf_tags analytical %}
-{% spaceless %}
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
@@ -80,4 +79,3 @@
 
     <script src="{% static 'dist/main.js' %}"></script></body>
 </html>
-{% endspaceless %}

--- a/ietf/templates_src/base.html
+++ b/ietf/templates_src/base.html
@@ -1,5 +1,4 @@
 {% load compress static wagtailuserbar wagtailcore_tags wagtailimages_tags ietf_tags analytical %}
-{% spaceless %}
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
@@ -77,4 +76,3 @@
         {% analytical_body_bottom %}
     </body>
 </html>
-{% endspaceless %}


### PR DESCRIPTION
Fixes https://github.com/ietf-tools/wagtail_website/issues/288

Django's [`{% spaceless %}`](https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#spaceless) template tag removes whitespace between HTML tags, including adjacent links. This patch removes the _spaceless_ tag from the base templates. It's still used in the `includes/imageblock.html` template, where it's not liable to squash adjacent inline markup: https://github.com/ietf-tools/wagtail_website/blob/v1.10.0/ietf/templates/includes/imageblock.html#L1