### PR TITLE
fix: Wagtail Editor Preview

### DIFF
--- a/docker/dev.env
+++ b/docker/dev.env
@@ -1,2 +1,3 @@
 APP_SECRET_KEY=xxxx
 DATABASE_URL=postgres://postgres:password@database/app
+ADDRESSES="*"


### PR DESCRIPTION
The Wagtail Editor Preview is broken on local, because it's making requests with the `Host` header set to `www.ietf.org`.

<img width="1387" alt="Screenshot 2023-12-06 at 13 30 50" src="https://github.com/ietf-tools/wagtail_website/assets/27617/7bf5fd59-9d04-4543-93c6-fbb5db1e3c18">
