### PR TITLE
fix: Social sharing box for IESG Statement pages

### DIFF
--- a/ietf/blog/templates/blog/blog_page.html
+++ b/ietf/blog/templates/blog/blog_page.html
@@ -52,7 +52,7 @@
                     </div>
 
                     <div class="px-3 px-xl-5 mt-5 mb-5">
-                        {% include "includes/social_share.html" with page=self settings=settings only %}
+                        {% include "includes/social_share.html" with page=self settings=settings current_site=current_site only %}
                     </div>
                     <nav aria-label="blog" class="row g-0 d-none d-lg-flex">
                         <div class="col-6 bg-primary p-4 ps-5 d-flex align-items-center">

--- a/ietf/iesg_statement/templates/iesg_statement/iesg_statement_page.html
+++ b/ietf/iesg_statement/templates/iesg_statement/iesg_statement_page.html
@@ -33,7 +33,7 @@
 
                     {% bibliography self %}
 
-                    {% include "includes/social_share.html" only %}
+                    {% include "includes/social_share.html" with page=self settings=settings current_site=current_site only %}
 
                 </div>
                 <nav aria-label="blog" class="row g-0 d-none d-lg-flex">

--- a/ietf/templates/includes/social_share.html
+++ b/ietf/templates/includes/social_share.html
@@ -10,6 +10,7 @@
     <{{ heading|default:"h2"}} class="h4">Share this page</{{ heading|default:"h2"}}>
 
     {% comment %}
+    {% spaceless %}
     <a
         class="me-2 h2"
         aria-label="Share on Facebook"
@@ -18,7 +19,9 @@
     >
         <span class="icon ion-social-facebook"></span>
     </a>
+    {% endspaceless %}
     {% endcomment %}
+    {% spaceless %}
     <a
         class="me-2 h2"
         title="Share on Twitter"
@@ -26,6 +29,8 @@
     >
         <span class="icon ion-social-twitter"></span>
     </a>
+    {% endspaceless %}
+    {% spaceless %}
     <a
         class="me-2 h2"
         title="Share on LinkedIn"
@@ -33,4 +38,5 @@
     >
         <span class="icon ion-social-linkedin"></span>
     </a>
+    {% endspaceless %}
 {% endwith %}


### PR DESCRIPTION
I've fixed a couple of issues, that I've noticed while working on another ticket, and the page http://localhost:8001/about/groups/iesg/statements/interim-meetings-guidance-2023-01-27/ crashed.

- Add missing variables passed into the social sharing sub-template (latent issue surfaced by https://github.com/ietf-tools/wagtail_website/pull/358).
- Remove spaces between social sharing icons (issue introduced in https://github.com/ietf-tools/wagtail_website/pull/347).
