### PR TITLE
fix: crash when previewing Event Listing Page

### DIFF
--- a/ietf/events/models.py
+++ b/ietf/events/models.py
@@ -210,8 +210,8 @@ class EventListingPage(Page, PromoteMixin):
             .descendant_of(self)
             .live()
             .exclude(
-                pk__in=self.promoted_events.all().values_list(
-                    "promoted_event__pk", flat=True
+                id__in=self.promoted_events.all().values_list(
+                    "promoted_event__id", flat=True
                 )
             )
             .order_by("start_date")
@@ -224,8 +224,8 @@ class EventListingPage(Page, PromoteMixin):
             .descendant_of(self)
             .live()
             .exclude(
-                pk__in=self.promoted_events.all().values_list(
-                    "promoted_event__pk", flat=True
+                id__in=self.promoted_events.all().values_list(
+                    "promoted_event__id", flat=True
                 )
             )
             .order_by("-start_date")


### PR DESCRIPTION
Fixes https://github.com/ietf-tools/wagtail_website/issues/327.

I was able to reproduce the error, and this patch makes it go away. I'm not entirely sure what was causing it. `pk` is an alias for the primary key field, which is `id` for the `EventPage` model, so in any case, the new code is still correct.