### PR TITLE
feat: Purge Cloudflare cache

### DIFF
--- a/ietf/settings/base.py
+++ b/ietf/settings/base.py
@@ -242,3 +242,15 @@ IAB_FEED_URL = "https://www.ietf.org/blog/iab/feed"
 IAB_IETF_BLOG_URL = "https://www.ietf.org/blog/iab/"
 
 NOTE_WELL_REPO = "https://raw.githubusercontent.com/ietf/note-well/main/note-well.md"
+
+_cf_purge_bearer_token = os.environ.get("CLOUDFLARE_CACHE_PURGE_BEARER_TOKEN")
+_cf_purge_zone_id = os.environ.get("CLOUDFLARE_CACHE_PURGE_ZONE_ID")
+if _cf_purge_bearer_token and _cf_purge_zone_id:
+    INSTALLED_APPS += ( "wagtail.contrib.frontend_cache", )
+    WAGTAILFRONTENDCACHE = {
+        "cloudflare": {
+            "BACKEND": "wagtail.contrib.frontend_cache.backends.CloudflareBackend",
+            "BEARER_TOKEN": _cf_purge_bearer_token,
+            "ZONEID": _cf_purge_zone_id,
+        },
+    }

--- a/ietf/utils/apps.py
+++ b/ietf/utils/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+from .signal_handlers import register_signal_handlers
+
+
+class UtilsAppConfig(AppConfig):
+    name = 'ietf.utils'
+    verbose_name = "IETF Website Utils"
+
+    def ready(self):
+        register_signal_handlers()

--- a/ietf/utils/signal_handlers.py
+++ b/ietf/utils/signal_handlers.py
@@ -1,0 +1,34 @@
+def register_signal_handlers():
+    from django.db.models.signals import post_delete, post_save
+    from wagtail.contrib.frontend_cache.utils import purge_pages_from_cache
+    from wagtail.models import Page, ReferenceIndex
+    from wagtail.signals import page_published, page_unpublished
+
+    from ietf.utils.models import MainMenuItem
+
+    def page_published_or_unpublished_handler(instance, **kwargs):
+        home_page = instance.get_site().root_page
+        purge_pages = set()
+
+        if not instance == home_page:
+            parent = instance.get_parent()
+            purge_pages.add(parent)
+
+        for obj, _ in ReferenceIndex.get_grouped_references_to(instance):
+            if isinstance(obj, Page):
+                if obj.live:
+                    purge_pages.add(obj)
+
+            if isinstance(obj, MainMenuItem):
+                purge_pages.add(home_page)
+
+        purge_pages_from_cache(list(purge_pages))
+
+    def main_menu_item_saved_or_deleted_handler(instance, **kwargs):
+        home_page = instance.page.get_site().root_page
+        purge_pages_from_cache([home_page])
+
+    page_published.connect(page_published_or_unpublished_handler)
+    page_unpublished.connect(page_published_or_unpublished_handler)
+    post_save.connect(main_menu_item_saved_or_deleted_handler, sender=MainMenuItem)
+    post_delete.connect(main_menu_item_saved_or_deleted_handler, sender=MainMenuItem)


### PR DESCRIPTION
Fixes https://github.com/ietf-tools/wagtail_website/issues/361.

### Additional setup
- Generate a Cloudflare _API token_ (not API key) with permissions to purge cache: https://docs.wagtail.org/en/stable/reference/contrib/frontendcache.html#cloudflare. Set it as the `CLOUDFLARE_CACHE_PURGE_BEARER_TOKEN` environment variable.
- Retrieve the Zone ID of the Cloudflare zone for www.ietf.org. Set it as the `CLOUDFLARE_CACHE_PURGE_ZONE_ID` environment variable.
- Change the Wagtail site (in the admin, Settings -> Sites) so that its port is 443. This tells Wagtail to generate `https://` URLs. Otherwise, it will try to purge `http://` URLs, which won't work.
- To test that cache purge works, run `curl -s https://www.ietf.org -I | grep cache`. It should print `cf-cache-status: HIT` for a cached page and `cf-cache-status: MISS` after it's purged.

### Cache purge rules
- When a page is published or unpublished:
  - Purge this page.
  - Purge this page's parent page.
  - Purge any pages which reference this page (e.g. with a link in a rich text block, or the "Promoted Events" list on the [Meetings page](https://www.ietf.org/how/meetings/)).
  - If a MainMenuItem references this page, purge the homepage. (Technically we should purge _all_ pages, but that's potentially expensive, as they have to be enumerated, and it seems overkill.)
- When a MainMenuItem is saved or deleted:
  - Purge the homepage.