### PR TITLE
fix:  Set CSRF_TRUSTED_ORIGINS

### DIFF
--- a/dev/deploy-to-container/cli.js
+++ b/dev/deploy-to-container/cli.js
@@ -161,6 +161,7 @@ async function main () {
       `CACHE_DEFAULT=ws-mc-${branch}:11211`,
       `CACHE_SESSIONS=ws-mc-${branch}:11211`,
       `ALLOWED_HOSTS=${hostname}`,
+      `CSRF_TRUSTED_ORIGINS=https://*.dev.ietf.org`,
       `PRIMARY_HOST=${hostname}`
     ],
     Labels: {

--- a/ietf/settings/production.py
+++ b/ietf/settings/production.py
@@ -31,6 +31,9 @@ if 'SECRET_KEY' in env:
 if 'ALLOWED_HOSTS' in env:
     ALLOWED_HOSTS = env['ALLOWED_HOSTS'].split(',')
 
+if 'CSRF_TRUSTED_ORIGINS' in env:
+    CSRF_TRUSTED_ORIGINS = env['CSRF_TRUSTED_ORIGINS'].split(',')
+
 if 'PRIMARY_HOST' in env:
     WAGTAILADMIN_BASE_URL = 'http://%s/' % env['PRIMARY_HOST']
 


### PR DESCRIPTION
Fixes #374

Production and staging deployments will need setting `CSRF_TRUSTED_ORIGINS` on `local.py`.