### PR TITLE
fix: Generate local URLs for megamenu and skip empty links

### DIFF
--- a/ietf/utils/context_processors.py
+++ b/ietf/utils/context_processors.py
@@ -23,7 +23,7 @@ class MainMenu:
         if page := link.get("page"):
             return page.get_url(current_site=self.site)
 
-        return "#"
+        return ""
 
     def get_link_title(self, link):
         if title := link.get("title"):
@@ -33,6 +33,15 @@ class MainMenu:
             return page.title
 
         return link.get("external_url")
+
+    def get_section_links(self, section):
+        for link in section.value.get("links"):
+            item = {
+                "title": self.get_link_title(link),
+                "url": self.get_link_url(link),
+            }
+            if item["title"] and item["url"]:
+                yield item
 
     def get_menu_item(self, item):
         main_section_links = [
@@ -45,13 +54,7 @@ class MainMenu:
         secondary_sections = [
             {
                 "title": section.value.get("title"),
-                "links": [
-                    {
-                        "title": self.get_link_title(link),
-                        "url": self.get_link_url(link),
-                    }
-                    for link in section.value.get("links")
-                ]
+                "links": list(self.get_section_links(section)),
             }
             for section in item.secondary_sections
         ]

--- a/ietf/utils/context_processors.py
+++ b/ietf/utils/context_processors.py
@@ -4,6 +4,9 @@ from ietf.utils.models import MainMenuItem
 
 
 class MainMenu:
+    def __init__(self, site):
+        self.site = site
+
     def get_items(self):
         return MainMenuItem.objects.all().select_related("page")
 
@@ -18,7 +21,7 @@ class MainMenu:
             return external_url
 
         if page := link.get("page"):
-            return page.url
+            return page.get_url(current_site=self.site)
 
         return "#"
 
@@ -32,7 +35,13 @@ class MainMenu:
         return link.get("external_url")
 
     def get_menu_item(self, item):
-        main_section_links = item.page.get_children().live().in_menu()
+        main_section_links = [
+            {
+                "title": page.title,
+                "url": item.page.get_url(current_site=self.site),
+            }
+            for page in item.page.get_children().live().in_menu()
+        ]
         secondary_sections = [
             {
                 "title": section.value.get("title"),
@@ -49,7 +58,7 @@ class MainMenu:
         return {
             "main_menu_item": item,
             "title": item.page.title,
-            "url": item.page.url if item.page.live else "",
+            "url": item.page.get_url(current_site=self.site) if item.page.live else "",
             "introduction": self.get_introduction(item.page.specific),
             "image": item.image,
             "main_section_links": main_section_links,
@@ -65,7 +74,8 @@ class MainMenu:
 
 
 class PreviewMainMenu(MainMenu):
-    def __init__(self, obj):
+    def __init__(self, site, obj):
+        super().__init__(site)
         self.obj = obj
 
     def get_items(self):
@@ -93,4 +103,4 @@ def get_main_menu(site):
     if "iab" in site.hostname:
         return get_iab_main_menu(site)
 
-    return MainMenu().get_menu()
+    return MainMenu(site).get_menu()

--- a/ietf/utils/models.py
+++ b/ietf/utils/models.py
@@ -6,7 +6,7 @@ from modelcluster.models import ClusterableModel
 from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
 from wagtail.fields import StreamField
-from wagtail.models import Orderable, PreviewableMixin
+from wagtail.models import Orderable, PreviewableMixin, Site
 from wagtailorderable.models import Orderable as WagtailOrderable
 
 from ietf.utils.blocks import MainMenuSection
@@ -135,9 +135,11 @@ class MainMenuItem(PreviewableMixin, models.Model):
     def get_preview_context(self, request, model_name):
         from .context_processors import PreviewMainMenu
 
+        site = Site.find_for_request(request)
+
         return {
             **super().get_preview_context(request, model_name),
-            "MENU": PreviewMainMenu(self).get_menu(),
+            "MENU": PreviewMainMenu(site, self).get_menu(),
             "MENU_PREVIEW": self,
         }
 


### PR DESCRIPTION
Refs. https://github.com/ietf-tools/wagtail_website/issues/326

I was testing what happens when a page from the megamenu is deleted, something I'd skipped over in the main PR, and found a couple of related issues.

With this change, if a page is deleted, its link becomes empty, and it will be skipped when rendering the menu.

This PR also makes local development slightly easier: in the megamenu, links to pages will be [generated](https://docs.wagtail.org/en/stable/reference/pages/model_reference.html#wagtail.models.Page.get_url) as _local URLs_, so that they point to _localhost_ instead of _www.ietf.org_.

Additionally, after applying the [utils.0009_megamenu](https://github.com/ietf-tools/wagtail_website/blob/main/ietf/utils/migrations/0009_megamenu.py) migration, I suggest running `./manage.py rebuild_references_index`. This way, when deleting a page that is part of the megamenu, the CMS will include the `MainMenuItem` object in its list of references. (References are normally kept up to date, but when creating content through migrations, the relevant hook doesn't get called.)
