### PR TITLE
ci: Build images for multiple platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         context: .
         file: docker/Dockerfile
         target: app-sandbox
-        # platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.buildvars.outputs.image_tags }}
 


### PR DESCRIPTION
Build images for `linux/amd64` and `linux/arm64`.
Fixes #413