### PR TITLE
chore: Automate collectstatic and migrate commands

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -143,4 +143,10 @@ RUN chmod +x /app/init.sh
 
 RUN mkdir -p /app/media
 
+# Configure environment variables (each with a placeholder) required
+# to bootstrap Django, so that collectstatic can run successfully
+RUN APP_SECRET_KEY="abcdef" \
+    DATABASE_URL="postgresql://userspec@hostspec/dbname?paramspec" \
+    python /app/manage.py collectstatic --no-input
+
 CMD ["./init.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -138,6 +138,9 @@ EOF
 COPY docker/nginx-sandbox.conf /etc/nginx/sites-enabled/default
 COPY docker/supervisord-sandbox.conf /app/supervisord.conf
 
+COPY docker/init.sh /app/init.sh
+RUN chmod +x /app/init.sh
+
 RUN mkdir -p /app/media
 
-CMD ["/usr/bin/supervisord", "-c", "/app/supervisord.conf"]
+CMD ["./init.sh"]

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Running management commands..."
-. deploy.sh
+python manage.py collectstatic --no-input
 
 echo "Starting supervisor..."
 /usr/bin/supervisord -c /app/supervisord.conf

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Running management commands..."
+echo "Running collectstatic..."
 python /app/manage.py collectstatic --no-input
 
 echo "Starting supervisor..."

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Running management commands..."
+. deploy.sh
+
+echo "Starting supervisor..."
+/usr/bin/supervisord -c /app/supervisord.conf

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Running management commands..."
-python manage.py collectstatic --no-input
+python /app/manage.py collectstatic --no-input
 
 echo "Starting supervisor..."
 /usr/bin/supervisord -c /app/supervisord.conf

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-echo "Running collectstatic..."
-python /app/manage.py collectstatic --no-input
+echo "Running migrate..."
+python /app/manage.py migrate
 
 echo "Starting supervisor..."
 /usr/bin/supervisord -c /app/supervisord.conf


### PR DESCRIPTION
Fixes #426 

---

`deploy.sh` already exists, so it's being reused here. 

```sh
cat deploy.sh
```
```text
#!/bin/sh -e

cd $(dirname $(echo $0))

python manage.py collectstatic --no-input
python manage.py migrate --no-input
python manage.py update_index
```

We can expand the list if there are any commands missing that need to run on init.