### PR TITLE
fix: Use Nginx's port as container port in Helm chart

### DIFF
--- a/helm/templates/deployments/wagtail.yaml
+++ b/helm/templates/deployments/wagtail.yaml
@@ -44,7 +44,7 @@ spec:
     {{- end }}
           ports:
             - name: http
-              containerPort: 8000
+              containerPort: 80
               protocol: TCP
           livenessProbe:
             {{- toYaml $podValues.livenessProbe | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,7 +89,6 @@ wagtail:
   service:
     type: ClusterIP
     port: 80
-    targetPort: 8000
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
Fixes #425 

---

Datatracker was used as a reference during the initial build of the Helm chart, but there are some differences in port numbers being used.

|               | Nginx | Gunicorn |
|---------------|-------|----------|
| `datatracker` | 8000  | 8001     |
| `www`         | 80    | 8000     |

The Helm chart has been updated accordingly.
