### PR TITLE
chore: Fix issue without traling slash. (#499)

### DIFF
--- a/k8s/ietfweb/nginx-default.conf
+++ b/k8s/ietfweb/nginx-default.conf
@@ -20,7 +20,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /charter {
+    location /charter/ {
         alias /a/ietfdata/doc/charter/;
         autoindex on;
         autoindex_exact_size off;
@@ -33,7 +33,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /cr {
+    location /cr/ {
         alias /a/ietfdata/doc/conflict-review/;
         autoindex on;
         autoindex_exact_size off;
@@ -46,7 +46,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /slides {
+    location /slides/ {
         alias /a/ietfdata/doc/slides/;
         autoindex on;
         autoindex_exact_size off;
@@ -59,7 +59,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /archive/id {
+    location /archive/id/ {
         alias /a/ietfdata/draft/archive/;
         autoindex on;
         autoindex_exact_size off;
@@ -72,7 +72,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /id {
+    location /id/ {
         alias /a/ietfdata/draft/repository;
         autoindex on;
         autoindex_exact_size off;
@@ -85,7 +85,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /ietf-ftp {
+    location /ietf-ftp/ {
         alias /a/www/ietf-ftp;
         autoindex on;
         autoindex_exact_size off;
@@ -98,7 +98,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /rfc {
+    location /rfc/ {
         alias /a/www/ietf-ftp/rfc;
         autoindex on;
         autoindex_exact_size off;
@@ -111,7 +111,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /proceedings {
+    location /proceedings/ {
         alias /a/www/www6s/proceedings;
         autoindex on;
         autoindex_exact_size off;
@@ -120,7 +120,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /download {
+    location /download/ {
         alias /a/www/www6s/download;
         autoindex on;
         autoindex_exact_size off;
@@ -129,7 +129,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /lib {
+    location /lib/ {
         alias /a/www/www6s/lib;
         autoindex on;
         autoindex_exact_size off;
@@ -139,7 +139,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /staging {
+    location /staging/ {
         alias /a/www/www6s/staging;
         autoindex on;
         autoindex_exact_size off;
@@ -148,7 +148,7 @@ server {
 
         error_page 404 = @error_redirect;
     }
-    location /status-report {
+    location /status-report/ {
         alias /a/www/www6s/status-report;
         autoindex on;
         autoindex_exact_size off;


### PR DESCRIPTION
>If a location is defined by a prefix string that ends with the slash character, and requests are processed by one of [proxy_pass](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass), [fastcgi_pass](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_pass), [uwsgi_pass](http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_pass), [scgi_pass](http://nginx.org/en/docs/http/ngx_http_scgi_module.html#scgi_pass), [memcached_pass](http://nginx.org/en/docs/http/ngx_http_memcached_module.html#memcached_pass), or [grpc_pass](http://nginx.org/en/docs/http/ngx_http_grpc_module.html#grpc_pass), then the special processing is performed. In response to a request with URI equal to this string, but without the trailing slash, a permanent redirect with the code 301 will be returned to the requested URI with the slash appended.

http://nginx.org/en/docs/http/ngx_http_core_module.html#location

Also see: https://nginx.org/en/docs/http/ngx_http_autoindex_module.html
`ngx_http_autoindex_module` expects a trailing `/`.