### PR TITLE
chore: Set gunicorn limit-request-line

### DIFF
--- a/docker/gunicorn.py
+++ b/docker/gunicorn.py
@@ -18,6 +18,7 @@ access_log_format = json.dumps(
 )
 capture_output = True
 forwarded_allow_ips = "*"
+limit_request_line = 2048
 # setting workers + threads = 2 * number of cores
 workers = 4
 threads = 4


### PR DESCRIPTION
Set `gunicorn` `limit-request-line`[^1] to `2048` to match django redirect limits.

Fixes #580 

[^1]: https://docs.gunicorn.org/en/stable/settings.html#limit-request-line