### PR TITLE
fix(ietf): Use correct order for meta description

### DIFF
--- a/ietf/templates_src/base.html
+++ b/ietf/templates_src/base.html
@@ -13,7 +13,11 @@
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>IETF {% block title %}{% if self.seo_title %} | {{ self.seo_title }}{% else %} | {{ self.title }}{% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
+        {% if self.search_description %}
+        <meta name="description" content="{{ self.search_description }}" />
+        {% else %}
         <meta name="description" content="{% social_text page current_site %}" />
+        {% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
         <!-- Twitter summary card - see https://dev.twitter.com/cards/types/summary -->


### PR DESCRIPTION
Fixes #642

If **SEO Meta description** is set use that otherwise fall back to the **Social/Meta descriptions >  Social text**.

